### PR TITLE
tlgu.c: fixed type specifier missing warning

### DIFF
--- a/tlgu.c
+++ b/tlgu.c
@@ -216,7 +216,7 @@ void usage_info(void)
 	printf("\n");
 }
 
-main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
 	unsigned char ucc;	/* test variable */
 	int idx;


### PR DESCRIPTION
main function had type specifier missing warning so return type 'int' added.
`gcc -o tlgu  tlgu.c
tlgu.c:219:1: warning: type specifier missing, defaults to 'int'
      [-Wimplicit-int]
main(int argc, char * argv[])
^
1 warning generated.`
I updated my cltk_data 's tlgu.c and ran nosetest which gave no errors or warnings :)